### PR TITLE
Fix tag usages in extensions

### DIFF
--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -760,6 +760,7 @@ private Ngrams ngrams;
                 if(!tagsInExtensions) {
                     return;
                 }
+		break;
             default:
                 return;
         }


### PR DESCRIPTION
A missing break in the case statement caused the tagsInExtensions check to continue down to the default case, instantly returning from the method.