### PR TITLE
Fix auto decode & convert

### DIFF
--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -1057,16 +1057,15 @@ public class BurpExtender implements IBurpExtender, ITab, IContextMenuFactory, I
         autodecodeConvert.addActionListener(e -> {
             if (invocation.getInvocationContext() == IContextMenuInvocation.CONTEXT_MESSAGE_EDITOR_REQUEST || invocation.getInvocationContext() == IContextMenuInvocation.CONTEXT_MESSAGE_VIEWER_REQUEST) {
                 byte[] message = invocation.getSelectedMessages()[0].getRequest();
+                byte[] selection = Arrays.copyOfRange(message, bounds[0], bounds[1]);
                 ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
                 try {
+                    byte[] convertedSelection = helpers.stringToBytes(auto_decode_no_decrypt(helpers.bytesToString(selection)));
                     outputStream.write(Arrays.copyOfRange(message, 0, bounds[0]));
-                    outputStream.write(helpers.stringToBytes("<@auto_decode_no_decrypt>"));
-                    outputStream.write(Arrays.copyOfRange(message, bounds[0], bounds[1]));
-                    outputStream.write(helpers.stringToBytes("<@/auto_decode_no_decrypt>"));
+                    outputStream.write(convertedSelection);
                     outputStream.write(Arrays.copyOfRange(message, bounds[1], message.length));
                     outputStream.flush();
-                    byte[] taggedMessage = outputStream.toByteArray();
-                    invocation.getSelectedMessages()[0].setRequest(helpers.stringToBytes(hackvertor.convert(helpers.bytesToString(taggedMessage))));
+                    invocation.getSelectedMessages()[0].setRequest(outputStream.toByteArray());
                 } catch (IOException e1) {
                     System.err.println(e1.toString());
                 }

--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -1065,12 +1065,11 @@ public class BurpExtender implements IBurpExtender, ITab, IContextMenuFactory, I
                     outputStream.write(helpers.stringToBytes("<@/auto_decode_no_decrypt>"));
                     outputStream.write(Arrays.copyOfRange(message, bounds[1], message.length));
                     outputStream.flush();
-                    invocation.getSelectedMessages()[0].setRequest(outputStream.toByteArray());
+                    byte[] taggedMessage = outputStream.toByteArray();
+                    invocation.getSelectedMessages()[0].setRequest(helpers.stringToBytes(hackvertor.convert(helpers.bytesToString(taggedMessage))));
                 } catch (IOException e1) {
                     System.err.println(e1.toString());
                 }
-                message = invocation.getSelectedMessages()[0].getRequest();
-                invocation.getSelectedMessages()[0].setRequest(helpers.stringToBytes(hackvertor.convert(helpers.bytesToString(message))));
             }
         });
         submenu.add(autodecodeConvert);


### PR DESCRIPTION
The context menu "Auto Decode & Convert" stopped working in the recent versions of Burp Suite.
Moreover, the implementation would not allow to use the feature more than once since the next call for the option would result in previously decoded blocks being encoded again.

This PR fixes both of the issues.