### PR TITLE
Gradle update and GitHub workflow fix

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,8 +6,12 @@ name: Java CI with Maven
 on:
   push:
     branches: [ master ]
+    tags:
+      - 'v*'
   pull_request:
     branches: [ master ]
+    tags:
+      - 'v*'
 
 jobs:
   build:
@@ -15,10 +19,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'oracle'
+          java-version: '17'
+          cache: 'gradle'
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew build
+      - name: Creating the jar file
+        run: ./gradlew jar
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./releases/*.jar
+          name: Downloadable Extension File
+      - name: Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: "latest_builds_by_github"
+          allowUpdates: true
+          artifacts: "releases/*.jar"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,7 +38,7 @@ jobs:
           path: ./releases/*.jar
           name: Downloadable Extension File
       - name: Release
-        uses: ncipollo/release-action@v1
+        uses: hackvertor/release-action@v1
         with:
           tag: "latest_builds_by_github"
           allowUpdates: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ bin/
 build/
 target/
 out/
+/releases/
 #intellij
 .idea/
 .classpath/

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ dependencies {
     implementation 'com.github.javafaker:javafaker:1.0.2'
     implementation 'com.fifesoft:rsyntaxtextarea:3.2.2'
     implementation 'com.fifesoft:autocomplete:3.3.1'
-    testImplementation 'junit:junit:4.13.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.7.1'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
 }
 
 sourceSets {
@@ -44,6 +44,24 @@ sourceSets {
     }
 }
 
+jar{
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    archivesBaseName = project.name + '-all'
+    from {
+        (configurations.runtimeClasspath).collect { it.isDirectory() ? it : zipTree(it) }
+    }{
+        exclude "META-INF/*.SF"
+        exclude "META-INF/*.DSA"
+        exclude "META-INF/*.RSA"
+        exclude "META-INF/*.txt"
+    }
+}
+
+tasks.withType(Jar) {
+    destinationDirectory = file("$rootDir/releases/")
+}
+
+/*
 task fatJar(type: Jar) {
     baseName = project.name + '-all'
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
@@ -58,6 +76,7 @@ task fatJar(type: Jar) {
     }
     with jar
 }
+*/
 
 /*test {
     useJUnitPlatform()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This should update the Gradle file to use the latest updates. It also fix the GitHub workflow to use Java 17 and to add the latest build to the release section. You can always delete that part if you don't like it as we can always get the latest build manually from the Actions tab.