### PR TITLE
Fix parsing of Content-Length as first header

### DIFF
--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -1463,6 +1463,8 @@ public class BurpExtender implements IBurpExtender, ITab, IContextMenuFactory, I
     public int[] getHeaderOffsets(byte[] request, String header) {
         int i = 0;
         int end = request.length;
+        while (i < end && request[i++] != '\n') {
+        }
         while (i < end) {
             int line_start = i;
             while (i < end && request[i++] != ':') {


### PR DESCRIPTION
When Hackvertor parses headers to update `Content-Length`, it incorrectly considers the first line of the request a part of the first header's name, therefore failing to find `Content-Length` when it is the first header of the request.

Example (must use HTTP/1.1 to reproduce):

```http
GET / HTTP/1.1
Content-Length: 0
Host: example.com
X-Foobar: <@random_alphanum_mixed(10)/>
```

For this request Hackvertor will identify the first header's name as `GET / HTTP/1.1\r\nContent-Length` and will not recognize it as `Content-Length`, resulting in the following error and the request sent with any Hackvertor tags not replaced:

```
java.lang.RuntimeException: Can't find the header
	at burp.BurpExtender.setHeader(BurpExtender.java:1503)
	at burp.BurpExtender.fixContentLength(BurpExtender.java:1457)
	at burp.BurpExtender.processHttpMessage(BurpExtender.java:1564)
```

This should resolve #103.