### PR TITLE
fix: jwt tag

### DIFF
--- a/src/main/java/burp/hv/Convertors.java
+++ b/src/main/java/burp/hv/Convertors.java
@@ -1412,10 +1412,7 @@ public class Convertors {
                 return "Unsupported algorithm";
             }
             String message = "";
-            String header = "{\n" +
-                    "  \"alg\": \"" + algo + "\",\n" +
-                    "  \"typ\": \"JWT\"\n" +
-                    "}";
+            String header = "{\"alg\":\"" + algo + "\",\"type\":\"JWT\"}";
             message = base64urlEncode(header) + "." + base64urlEncode(payload);
             if (!algoName.equals("none")) {
                 Mac hashMac = Mac.getInstance(algoName);


### PR DESCRIPTION
Fix the typo "typ" > "type"

Removed the new line (I wad a bit triggered but the base64 encoded valued starting with `ewo` instead of `eyJ`.